### PR TITLE
Remove missing module that causes fatal error

### DIFF
--- a/HyMD/pom.xml
+++ b/HyMD/pom.xml
@@ -35,7 +35,6 @@
     <module>util</module>
     <module>db</module>
     <module>sim</module>
-    <module>data</module>
     <module>hybrid</module>
     <module>mapping</module>
     <module>config</module>


### PR DESCRIPTION
A clean copy of the repository does not build, because the module "data" does not exist.