### PR TITLE
Update cobertura-maven-plugin and maven-assembly-plugin

### DIFF
--- a/AIDFD/pom.xml
+++ b/AIDFD/pom.xml
@@ -44,7 +44,7 @@
 			<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/BINDER/BINDERAlgorithm/pom.xml
+++ b/BINDER/BINDERAlgorithm/pom.xml
@@ -83,7 +83,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>
@@ -110,7 +110,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
+        <version>2.7</version>
         <configuration>
           <formats>
             <format>xml</format>

--- a/BINDER/BINDERDatabase/pom.xml
+++ b/BINDER/BINDERDatabase/pom.xml
@@ -55,7 +55,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/BINDER/BINDERFile/pom.xml
+++ b/BINDER/BINDERFile/pom.xml
@@ -55,7 +55,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/CFDFinder/pom.xml
+++ b/CFDFinder/pom.xml
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/DVA/pom.xml
+++ b/DVA/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVAKMV/pom.xml
+++ b/DVAKMV/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVAMS/pom.xml
+++ b/DVAMS/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVBJKST/pom.xml
+++ b/DVBJKST/pom.xml
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVBloomFilter/pom.xml
+++ b/DVBloomFilter/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVFM/pom.xml
+++ b/DVFM/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVHyperLogLog/pom.xml
+++ b/DVHyperLogLog/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVHyperLogLogPlus/pom.xml
+++ b/DVHyperLogLogPlus/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVLC/pom.xml
+++ b/DVLC/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVLogLog/pom.xml
+++ b/DVLogLog/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVMinCount/pom.xml
+++ b/DVMinCount/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVPCSA/pom.xml
+++ b/DVPCSA/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/DVSuperLogLog/pom.xml
+++ b/DVSuperLogLog/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/FAIDA/FAIDAAlgorithm/pom.xml
+++ b/FAIDA/FAIDAAlgorithm/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/HyFD/pom.xml
+++ b/HyFD/pom.xml
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/HyMD/metanome/pom.xml
+++ b/HyMD/metanome/pom.xml
@@ -72,7 +72,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/HyUCC/pom.xml
+++ b/HyUCC/pom.xml
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/MANY/pom.xml
+++ b/MANY/pom.xml
@@ -85,7 +85,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.1.1</version>
 				<configuration>
 					<archive>
 						<manifest>

--- a/MvdDet/pom.xml
+++ b/MvdDet/pom.xml
@@ -69,7 +69,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/Normalize/pom.xml
+++ b/Normalize/pom.xml
@@ -107,7 +107,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/ORDER/pom.xml
+++ b/ORDER/pom.xml
@@ -94,7 +94,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.2.1</version>
+				<version>3.1.1</version>
 				<configuration>
 					<archive>
 						<manifestEntries>

--- a/SCDP/pom.xml
+++ b/SCDP/pom.xml
@@ -81,7 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/SPIDER/SPIDERAlgorithm/pom.xml
+++ b/SPIDER/SPIDERAlgorithm/pom.xml
@@ -83,7 +83,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>
@@ -110,7 +110,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
+        <version>2.7</version>
         <configuration>
           <formats>
             <format>xml</format>

--- a/SPIDER/SPIDERDatabase/pom.xml
+++ b/SPIDER/SPIDERDatabase/pom.xml
@@ -55,7 +55,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/SPIDER/SPIDERFile/pom.xml
+++ b/SPIDER/SPIDERFile/pom.xml
@@ -55,7 +55,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/dcucc/dcucc/pom.xml
+++ b/dcucc/dcucc/pom.xml
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -131,7 +131,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.7</version>
                 <configuration>
                     <formats>
                         <format>xml</format>

--- a/depminer/depminer_algorithm/pom.xml
+++ b/depminer/depminer_algorithm/pom.xml
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/depminer/depminer_helper/pom.xml
+++ b/depminer/depminer_helper/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/dfd/dfdMetanome/pom.xml
+++ b/dfd/dfdMetanome/pom.xml
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/ducc/ducc_algorithm/pom.xml
+++ b/ducc/ducc_algorithm/pom.xml
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -110,7 +110,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.7</version>
                 <configuration>
                     <formats>
                         <format>xml</format>

--- a/ducc/ducc_algorithm_helper/pom.xml
+++ b/ducc/ducc_algorithm_helper/pom.xml
@@ -72,7 +72,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.7</version>
                 <configuration>
                     <formats>
                         <format>xml</format>

--- a/ducc/ducc_for_metanome/pom.xml
+++ b/ducc/ducc_for_metanome/pom.xml
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -110,7 +110,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.7</version>
                 <configuration>
                     <formats>
                         <format>xml</format>

--- a/fastfds/fastfds_algorithm/pom.xml
+++ b/fastfds/fastfds_algorithm/pom.xml
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/fastfds/fastfds_helper/pom.xml
+++ b/fastfds/fastfds_helper/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/fdep/fdep_algorithm/pom.xml
+++ b/fdep/fdep_algorithm/pom.xml
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/fdep/fdep_algorithm_improved/pom.xml
+++ b/fdep/fdep_algorithm_improved/pom.xml
@@ -55,7 +55,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/fdmine/fdmine_algorithm/pom.xml
+++ b/fdmine/fdmine_algorithm/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/fun/fun_algorithm/pom.xml
+++ b/fun/fun_algorithm/pom.xml
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/fun/fun_algorithm_helper/pom.xml
+++ b/fun/fun_algorithm_helper/pom.xml
@@ -70,7 +70,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.7</version>
                 <configuration>
                     <formats>
                         <format>xml</format>

--- a/fun/fun_for_metanome/pom.xml
+++ b/fun/fun_for_metanome/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/hydra/pom.xml
+++ b/hydra/pom.xml
@@ -72,7 +72,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.2.1</version>
+				<version>3.1.1</version>
 				<configuration>
 					<archive>
 						<manifestEntries>

--- a/tane/tane_algorithm/pom.xml
+++ b/tane/tane_algorithm/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/tane/tane_tree_dir_algorithm/pom.xml
+++ b/tane/tane_tree_dir_algorithm/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/tane/tane_tree_end_algorithm/pom.xml
+++ b/tane/tane_tree_end_algorithm/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>


### PR DESCRIPTION
I was unable to build on Java 8 without updating these two plugins.
Everything builds flawlessly now.